### PR TITLE
feat: Task 등록 화면 UI 구성 및 공통 컴포넌트 적용

### DIFF
--- a/MungDo/Presentation/Component/Button/CustomButton.swift
+++ b/MungDo/Presentation/Component/Button/CustomButton.swift
@@ -1,0 +1,30 @@
+//
+//  CustomButton.swift
+//  MungDo
+//
+//  Created by 제하맥 on 6/2/25.
+//
+
+import SwiftUI
+
+struct CustomButton: View {
+    let title: String
+    let isEnabled: Bool
+    let action: () -> Void
+    var width: CGFloat = 316
+    var height: CGFloat = 64
+    var fontSize: CGFloat = 20
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: fontSize, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(width: width, height: height)
+                .background(isEnabled ? Color.buttonPrimary : Color.buttonDisable)
+                .cornerRadius(18)
+        }
+        .disabled(!isEnabled)
+    }
+}
+

--- a/MungDo/Presentation/Component/NavigationBar/CustomNavigationBar.swift
+++ b/MungDo/Presentation/Component/NavigationBar/CustomNavigationBar.swift
@@ -1,0 +1,47 @@
+//
+//  CustomNavigationBar.swift
+//  MungDo
+//
+//  Created by 제하맥 on 6/2/25.
+//
+
+import SwiftUI
+
+struct CustomNavigationBar: View {
+    var showDepth: Bool = false
+    var currentDepth: Int = 1
+    var totalDepth: Int = 1
+    var onBack: () -> Void
+
+    var body: some View {
+        HStack {
+            Button(action: {
+                onBack()
+            }) {
+                Image(systemName: "chevron.left")
+                    .resizable()
+                    .frame(width: 12, height: 20)
+                    .foregroundColor(Color.buttonSecondary)
+                    .frame(width: 22, height: 36, alignment: .leading)
+            }
+
+            Spacer()
+
+            if showDepth {
+                DepthIndicator(current: currentDepth, total: totalDepth)
+                    .frame(maxWidth: .infinity)
+            }
+
+            Spacer()
+            
+            // 공간 균형 맞추기 위한 투명 버튼
+            if showDepth {
+                Rectangle()
+                    .frame(width: 22, height: 36)
+                    .opacity(0)
+            }
+        }
+        .padding(.top, 80)
+
+    }
+}

--- a/MungDo/Presentation/Component/NavigationBar/DepthIndicator.swift
+++ b/MungDo/Presentation/Component/NavigationBar/DepthIndicator.swift
@@ -1,0 +1,37 @@
+//
+//  DepthIndicator.swift
+//  MungDo
+//
+//  Created by 제하맥 on 6/2/25.
+//
+
+import SwiftUI
+
+struct DepthIndicator: View {
+    var current: Int
+    var total: Int
+
+    var body: some View {
+        HStack(spacing: 10) {
+            ForEach(1...total, id: \.self) { index in
+                if index == current {
+                    // 강조된 현재 단계
+                    Text("\(index)")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundColor(.white)
+                        .frame(width: 36, height: 36)
+                        .background(Color.buttonSecondary)
+                        .clipShape(Circle())
+                } else {
+                    // 비활성 단계
+                    Text("\(index)")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(.white.opacity(0.8))
+                        .frame(width: 22, height: 22)
+                        .background(Color.buttonDisable)
+                        .clipShape(Circle())
+                }
+            }
+        }
+    }
+}

--- a/MungDo/Presentation/Screen/Add/NameAddTask/NameAddTaskView.swift
+++ b/MungDo/Presentation/Screen/Add/NameAddTask/NameAddTaskView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct NameAddTaskView: View {
     var body: some View {
         VStack(spacing: 30) {
-            Text("Add Name Task View")
+            Text("어떤 일을 추가할까요?")
                 .font(.largeTitle)
                 .fontWeight(.bold)
             

--- a/MungDo/Presentation/Screen/Add/NameAddTask/NameAddTaskView.swift
+++ b/MungDo/Presentation/Screen/Add/NameAddTask/NameAddTaskView.swift
@@ -8,29 +8,48 @@
 import SwiftUI
 
 struct NameAddTaskView: View {
+    let taskTitles = [
+            "심장사상충 약\n먹이기",
+            "산책하기",
+            "광견병·코로나\n예방접종하기",
+            "목욕하기",
+            "외부기생충 약\n먹이기"
+        ]
+    
+    @State private var selectedIndex: Int? = nil
+    
     var body: some View {
-        VStack(spacing: 30) {
+        VStack(alignment: .leading, spacing: 28) {
             Text("어떤 일을 추가할까요?")
-                .font(.largeTitle)
-                .fontWeight(.bold)
+                .font(.system(size: 37, weight: .semibold))
+                .padding(28)
             
-            Text("태스크 이름을 추가하는 화면입니다")
-                .font(.body)
-                .foregroundColor(.gray)
-            
-            NavigationLink(destination: CalendarAddTaskView()) {
-                Text("Next: Calendar")
-                    .font(.title2)
-                    .foregroundColor(.white)
-                    .frame(width: 200, height: 50)
-                    .background(Color.blue)
-                    .cornerRadius(10)
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())], spacing: 28) {
+                ForEach(taskTitles.indices, id: \.self) { index in
+                    TaskCardView(title: taskTitles[index], isSelected: selectedIndex == index)
+                        .onTapGesture {
+                            selectedIndex = index
+                        }
+                }
             }
-            
-            Spacer()
+
+            HStack{
+                Spacer()
+                NavigationLink(destination: CalendarAddTaskView()) {
+                    Text("다음")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundColor(.white)
+                        .frame(width: 316, height: 64)
+                        .background(selectedIndex == nil ? Color.buttonDisable : Color.buttonPrimary)
+                        .cornerRadius(18)
+                }
+                .disabled(selectedIndex == nil)
+                Spacer()
+            }
+            .padding(.bottom, 28)
         }
-        .padding()
-        .navigationTitle("Add Name")
+        .padding(55)
+        .background(Color.backgroundPrimary)
     }
 }
 

--- a/MungDo/Presentation/Screen/Add/NameAddTask/NameAddTaskView.swift
+++ b/MungDo/Presentation/Screen/Add/NameAddTask/NameAddTaskView.swift
@@ -21,8 +21,19 @@ struct NameAddTaskView: View {
     @State private var selectedIndex: Int? = nil
     @State private var goToNext = false
     
+    @Environment(\.dismiss) private var dismiss
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 28) {
+            CustomNavigationBar(
+                showDepth: true,
+                currentDepth: 1,
+                totalDepth: 2,
+                onBack: {
+                    dismiss()
+                }
+            )
+            
             Text(title)
                 .font(.system(size: 37, weight: .semibold))
                 .padding(28)
@@ -61,9 +72,12 @@ struct NameAddTaskView: View {
                     EmptyView()
                 }
             )
+            .padding(28)
         }
         .padding(55)
         .background(Color.backgroundPrimary)
+        .navigationBarBackButtonHidden(true) //수정: 기본 뒤로가기 버튼 숨김
+        .navigationBarHidden(true) //수정: 기본 내비게이션 바 숨김
     }
 }
 

--- a/MungDo/Presentation/Screen/Add/NameAddTask/NameAddTaskView.swift
+++ b/MungDo/Presentation/Screen/Add/NameAddTask/NameAddTaskView.swift
@@ -16,8 +16,10 @@ struct NameAddTaskView: View {
             "외부기생충 약\n먹이기"
         ]
     let title: String = "어떤 일을 추가할까요?"
+    let buttonTitle: String = "다음"
     
     @State private var selectedIndex: Int? = nil
+    @State private var goToNext = false
     
     var body: some View {
         VStack(alignment: .leading, spacing: 28) {
@@ -33,21 +35,32 @@ struct NameAddTaskView: View {
                         }
                 }
             }
-
-            HStack{
+            
+            HStack {
                 Spacer()
-                NavigationLink(destination: CalendarAddTaskView()) {
-                    Text("다음")
-                        .font(.system(size: 20, weight: .semibold))
-                        .foregroundColor(.white)
-                        .frame(width: 316, height: 64)
-                        .background(selectedIndex == nil ? Color.buttonDisable : Color.buttonPrimary)
-                        .cornerRadius(18)
+                NavigationActionButton(
+                    title: buttonTitle,
+                    isEnabled: selectedIndex != nil
+                ) {
+                    goToNext = true
                 }
-                .disabled(selectedIndex == nil)
                 Spacer()
             }
             .padding(.bottom, 28)
+            
+            NavigationLink(
+                destination: CalendarAddTaskView(),
+                //다음 페이지로 선택한 task 카테고리 전달하기
+                //destination: {
+                //  if let selectedIndex = selectedIndex {
+                //                      CalendarAddTaskView(taskTitle: taskTitles[selectedIndex])
+                //                        }
+                //                    },
+                isActive: $goToNext,
+                label: {
+                    EmptyView()
+                }
+            )
         }
         .padding(55)
         .background(Color.backgroundPrimary)

--- a/MungDo/Presentation/Screen/Add/NameAddTask/NameAddTaskView.swift
+++ b/MungDo/Presentation/Screen/Add/NameAddTask/NameAddTaskView.swift
@@ -49,7 +49,7 @@ struct NameAddTaskView: View {
             
             HStack {
                 Spacer()
-                NavigationActionButton(
+                CustomButton(
                     title: buttonTitle,
                     isEnabled: selectedIndex != nil
                 ) {

--- a/MungDo/Presentation/Screen/Add/NameAddTask/NameAddTaskView.swift
+++ b/MungDo/Presentation/Screen/Add/NameAddTask/NameAddTaskView.swift
@@ -15,12 +15,13 @@ struct NameAddTaskView: View {
             "목욕하기",
             "외부기생충 약\n먹이기"
         ]
+    let title: String = "어떤 일을 추가할까요?"
     
     @State private var selectedIndex: Int? = nil
     
     var body: some View {
         VStack(alignment: .leading, spacing: 28) {
-            Text("어떤 일을 추가할까요?")
+            Text(title)
                 .font(.system(size: 37, weight: .semibold))
                 .padding(28)
             

--- a/MungDo/Presentation/Screen/Add/NameAddTask/NavigationActionButton.swift
+++ b/MungDo/Presentation/Screen/Add/NameAddTask/NavigationActionButton.swift
@@ -1,0 +1,27 @@
+//
+//  NavigationActionButtonView.swift
+//  MungDo
+//
+//  Created by 제하맥 on 6/1/25.
+//
+
+
+import SwiftUI
+
+struct NavigationActionButton: View { // 수정
+    let title: String
+    let isEnabled: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(width: 316, height: 64)
+                .background(isEnabled ? Color.buttonPrimary : Color.buttonDisable)
+                .cornerRadius(18)
+        }
+        .disabled(!isEnabled)
+    }
+}

--- a/MungDo/Presentation/Screen/Add/NameAddTask/TaskCardView.swift
+++ b/MungDo/Presentation/Screen/Add/NameAddTask/TaskCardView.swift
@@ -1,0 +1,45 @@
+//
+//  TaskCardView.swift
+//  MungDo
+//
+//  Created by 제하맥 on 5/31/25.
+//
+
+import SwiftUI
+
+struct TaskCardView: View {
+    let title: String
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 16){
+            Circle()
+                .fill(Color.buttonDisable)
+                .frame(width: 96, height: 96)
+            Text(title)
+                .font(.system(size: 22, weight: .semibold))
+        }
+
+        .padding(.vertical, 46)
+        .padding(.horizontal, 41)
+        .frame(width: 316, height: 188, alignment: .topLeading)
+        .background(Color.white)
+        .cornerRadius(28)
+        .overlay(
+            RoundedRectangle(cornerRadius: 28)
+                .inset(by: 2)
+                .stroke(isSelected ? Color.buttonSecondary : Color.clear, lineWidth: 4)
+        )
+        .shadow(color: isSelected ? Color.clear : Color(red: 1, green: 0.44, blue: 0.38).opacity(0.08),
+                radius: 6, x: 0, y: 4)
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        TaskCardView(title: "심장사상충 약\n먹이기", isSelected: true)
+        TaskCardView(title: "산책하기", isSelected: false)
+    }
+    .padding()
+    .background(Color(red: 1.0, green: 0.95, blue: 0.92)) // 배경도 원본 화면과 유사하게 설정
+}

--- a/MungDo/Presentation/Screen/Add/NameAddTask/TaskCardView.swift
+++ b/MungDo/Presentation/Screen/Add/NameAddTask/TaskCardView.swift
@@ -41,5 +41,5 @@ struct TaskCardView: View {
         TaskCardView(title: "산책하기", isSelected: false)
     }
     .padding()
-    .background(Color(red: 1.0, green: 0.95, blue: 0.92)) // 배경도 원본 화면과 유사하게 설정
+    .background(Color.backgroundPrimary)
 }


### PR DESCRIPTION
# 📝 Pull Request 개요
Task 등록 기능을 구현하기 위한 UI 작업과 함께, 프로젝트 전반에서 재사용 가능한 공통 UI 컴포넌트들을 구성하였습니다.
향후 유지보수성과 일관된 디자인 적용을 고려하여 설계했습니다.

# 📌 주요 변경 사항
## 🔹 TaskCard 컴포넌트 구현
+ Task 항목을 카드 형태로 보여주는 UI 컴포넌트

+ 선택 여부에 따라 테두리 및 그림자 변화

+ 아이콘 영역 및 텍스트 폰트, 스타일 설정

## 🔹 NameAddTaskView UI 구성
+ TaskCard를 그리드 형태로 배치

+ 선택된 Task가 존재하는지에 따라 '다음' 버튼 활성화

## 🔹 CustomButton 컴포넌트 생성
+ 기존 '다음' 버튼 컴포넌트를 일반화

+ 버튼 텍스트, 활성화 상태, 크기 (width / height), 폰트 사이즈를 외부에서 설정 가능

+ 기본값 제공 (316x64, fontSize: 20)

## 🔹 CustomNavigationBar 및 DepthIndicator 적용
+ NavigationBar를 무시하고, 디자인에 맞춘 커스텀 바 구현

+ 뒤로가기 버튼과 DepthIndicator를 조합해 사용

+ DepthIndicator : 현재 페이지와 전체 페이지 수를 시각적으로 보여줌

